### PR TITLE
changing dev environment container image to avoid CVE-2022-37434

### DIFF
--- a/okteto.yml
+++ b/okteto.yml
@@ -1,6 +1,6 @@
 build:
   todo-list:
-    image: okteto.dev/todo-list:1.0.0
+    image: okteto.dev/todo-list:2.0.0
     context: .
   todo-list-dev:
     context: .


### PR DESCRIPTION
The `nginx-1.23.1-alpine` image being used in the Okteto manifest has been found to have the [CVE-2022-37434](https://nvd.nist.gov/vuln/detail/CVE-2022-37434). This PR rollbacks to the uncompromised version we were using previously.